### PR TITLE
Fixes 'NameError: reduce is not defined in Python' when attempting to use the in-memory train_word2vec in Python3.

### DIFF
--- a/magpie/base/word2vec.py
+++ b/magpie/base/word2vec.py
@@ -2,6 +2,7 @@ from __future__ import print_function, unicode_literals
 import os
 import six
 import numpy as np
+from functools import reduce
 
 from gensim.models import Word2Vec
 from sklearn.preprocessing import StandardScaler


### PR DESCRIPTION
Fixes 'NameError: reduce is not defined in Python' when attempting to use the in-memory train_word2vec in Python3.

This fix is compatible with Python2.7, and has been tested to work on
Python 3.5.2 on Ubuntu 16.04.3 LTS (4.10.0-22-generic).