### PR TITLE
Release Magpie 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Magpie is a deep learning tool for multi-label text classification. It learns on
 
 ## Very short introduction
 ```
->>> from magpie import MagpieModel
->>> magpie = MagpieModel()
+>>> magpie = Magpie()
 >>> magpie.init_word_vectors('/path/to/corpus', vec_dim=100)
 >>> magpie.train('/path/to/corpus', ['label1', 'label2', 'label3'], epochs=3)
 Training...
@@ -24,9 +23,9 @@ $ ls data/hep-categories
 
 Before you train the model, you need to build appropriate word vector representations for your corpus. In theory, you can train them on a different corpus or reuse already trained ones ([tutorial](http://rare-technologies.com/word2vec-tutorial/)), however Magpie enables you to do that as well.
 ```python
-from magpie import MagpieModel
+from magpie import Magpie
 
-magpie = MagpieModel()
+magpie = Magpie()
 magpie.train_word2vec('data/hep-categories', vec_dim=100)
 ```
 
@@ -41,7 +40,7 @@ You would usually want to combine those two steps, by simply running:
 magpie.init_word_vectors('data/hep-categories', vec_dim=100)
 ```
 
-If you plan to reuse the trained word representations, you might want to save them and pass in the constructor to `MagpieModel` next time. For the training, just type:
+If you plan to reuse the trained word representations, you might want to save them and pass in the constructor to `Magpie` next time. For the training, just type:
 ```python
 labels = ['Gravitation and Cosmology', 'Experiment-HEP', 'Theory-HEP']
 magpie.train('data/hep-categories', labels, test_ratio=0.2, epochs=30)
@@ -63,7 +62,7 @@ Trained models can be used for prediction with methods:
  ('Theory-HEP', 0.20917746)]
 ```
 ## Saving & loading the model
-A `MagpieModel` object consists of three components - the word2vec mappings, a scaler and a `keras` model. In order to train Magpie you can either provide the word2vec mappings and a scaler in advance or let the program compute them for you on the training data. Usually you would want to train them yourself on a full dataset and reuse them afterwards. You can use the provided functions for that purpose:
+A `Magpie` object consists of three components - the word2vec mappings, a scaler and a `keras` model. In order to train Magpie you can either provide the word2vec mappings and a scaler in advance or let the program compute them for you on the training data. Usually you would want to train them yourself on a full dataset and reuse them afterwards. You can use the provided functions for that purpose:
 
 ```python
 magpie.save_word2vec_model('/save/my/embeddings/here')
@@ -74,7 +73,7 @@ magpie.save_model('/save/my/model/here.h5')
 When you want to reinitialize your trained model, you can run:
 
 ```python
-magpie = MagpieModel(
+magpie = Magpie(
     keras_model='/save/my/model/here.h5',
     word2vec_model='/save/my/embeddings/here',
     scaler='/save/my/scaler/here',

--- a/README.md
+++ b/README.md
@@ -90,5 +90,8 @@ $ pip install git+https://github.com/inspirehep/magpie.git@v2.0
 ```
 If you encounter any problems with the installation, make sure to install the correct versions of dependencies listed in `setup.py` file.
 
+## Magpie v1.0 vs v2.0
+Magpie v1.0 depends on Keras v1.X, while Magpie v2.0 on Keras v2.X. You can install and use either of those, but bear in mind that only v2.0 will be developed in the future. If you have troubles with installation, make sure that both Magpie and Keras have the same major version.
+
 ## Contact
 If you have any problems, feel free to open an issue. We'll do our best to help :+1:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ or just pass the objects directly!
 
 The package is not on PyPi, but you can get it directly from GitHub:
 ```
-$ pip install git+https://github.com/inspirehep/magpie.git@v1.0
+$ pip install git+https://github.com/inspirehep/magpie.git@v2.0
 ```
 If you encounter any problems with the installation, make sure to install the correct versions of dependencies listed in `setup.py` file.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Magpie is a deep learning tool for multi-label text classification. It learns on
 >>> from magpie import MagpieModel
 >>> magpie = MagpieModel()
 >>> magpie.init_word_vectors('/path/to/corpus', vec_dim=100)
->>> magpie.train('/path/to/corpus', ['label1', 'label2', 'label3'], nb_epochs=3)
+>>> magpie.train('/path/to/corpus', ['label1', 'label2', 'label3'], epochs=3)
 Training...
 >>> magpie.predict_from_text('Well, that was quick!')
 [('label1', 0.96), ('label3', 0.65), ('label2', 0.21)]
@@ -44,7 +44,7 @@ magpie.init_word_vectors('data/hep-categories', vec_dim=100)
 If you plan to reuse the trained word representations, you might want to save them and pass in the constructor to `MagpieModel` next time. For the training, just type:
 ```python
 labels = ['Gravitation and Cosmology', 'Experiment-HEP', 'Theory-HEP']
-magpie.train('data/hep-categories', labels, test_ratio=0.2, nb_epochs=30)
+magpie.train('data/hep-categories', labels, test_ratio=0.2, epochs=30)
 ```
 By providing the `test_ratio` argument, the model splits data into train & test datasets (in this example into 80/20 ratio) and evaluates itself after every epoch displaying it's current loss and accuracy. The default value of `test_ratio` is 0 meaning that all the data will be used for training.
 

--- a/magpie/__init__.py
+++ b/magpie/__init__.py
@@ -1,1 +1,1 @@
-from .main import MagpieModel
+from .main import Magpie

--- a/magpie/config.py
+++ b/magpie/config.py
@@ -11,7 +11,7 @@ NN_ARCHITECTURE = 'cnn'
 
 # Training parameters
 BATCH_SIZE = 64
-NB_EPOCHS = 1
+EPOCHS = 1
 
 # Number of tokens to save from the abstract, zero padded
 SAMPLE_LENGTH = 200

--- a/magpie/main.py
+++ b/magpie/main.py
@@ -16,7 +16,7 @@ from magpie.nn.models import get_nn_model
 from magpie.utils import save_to_disk, load_from_disk
 
 
-class MagpieModel(object):
+class Magpie(object):
 
     def __init__(self, keras_model=None, word2vec_model=None, scaler=None,
                  labels=None):

--- a/magpie/tests/test_api.py
+++ b/magpie/tests/test_api.py
@@ -8,7 +8,7 @@ DATA_DIR = os.path.join(PROJECT_DIR, 'data', 'hep-categories')
 
 class TestAPI(unittest.TestCase):
 	""" Basic integration test """
-	def test_integrity(self):
+	def test_cnn_train(self):
 		# Get them labels!
 		with io.open(DATA_DIR + '.labels', 'r') as f:
 			labels = {line.rstrip('\n') for line in f}
@@ -17,7 +17,28 @@ class TestAPI(unittest.TestCase):
 		from magpie import MagpieModel
 		model = MagpieModel()
 		model.init_word_vectors(DATA_DIR, vec_dim=100)
-		history = model.train(DATA_DIR, labels, test_ratio=0.3, epochs=3)
+		history = model.train(DATA_DIR, labels, nn_model='cnn', test_ratio=0.3, epochs=3)
+		assert history is not None
+
+		# Do a simple prediction
+		predictions = model.predict_from_text("Black holes are cool!")
+		assert len(predictions) == len(labels)
+
+		# Assert the hell out of it!
+		for lab, val in predictions:
+			assert lab in labels
+			assert 0 <= val <= 1
+
+	def test_rnn_batch_train(self):
+		# Get them labels!
+		with io.open(DATA_DIR + '.labels', 'r') as f:
+			labels = {line.rstrip('\n') for line in f}
+
+		# Run the model
+		from magpie import MagpieModel
+		model = MagpieModel()
+		model.init_word_vectors(DATA_DIR, vec_dim=100)
+		history = model.batch_train(DATA_DIR, labels, nn_model='rnn', epochs=3)
 		assert history is not None
 
 		# Do a simple prediction

--- a/magpie/tests/test_api.py
+++ b/magpie/tests/test_api.py
@@ -2,6 +2,8 @@ import io
 import os
 import unittest
 
+from magpie import Magpie
+
 # This one is hacky, but I'm too lazy to do it properly!
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 DATA_DIR = os.path.join(PROJECT_DIR, 'data', 'hep-categories')
@@ -14,8 +16,7 @@ class TestAPI(unittest.TestCase):
 			labels = {line.rstrip('\n') for line in f}
 
 		# Run the model
-		from magpie import MagpieModel
-		model = MagpieModel()
+		model = Magpie()
 		model.init_word_vectors(DATA_DIR, vec_dim=100)
 		history = model.train(DATA_DIR, labels, nn_model='cnn', test_ratio=0.3, epochs=3)
 		assert history is not None
@@ -35,8 +36,7 @@ class TestAPI(unittest.TestCase):
 			labels = {line.rstrip('\n') for line in f}
 
 		# Run the model
-		from magpie import MagpieModel
-		model = MagpieModel()
+		model = Magpie()
 		model.init_word_vectors(DATA_DIR, vec_dim=100)
 		history = model.batch_train(DATA_DIR, labels, nn_model='rnn', epochs=3)
 		assert history is not None

--- a/magpie/tests/test_api.py
+++ b/magpie/tests/test_api.py
@@ -17,7 +17,7 @@ class TestAPI(unittest.TestCase):
 		from magpie import MagpieModel
 		model = MagpieModel()
 		model.init_word_vectors(DATA_DIR, vec_dim=100)
-		history = model.train(DATA_DIR, labels, test_ratio=0.3, nb_epochs=3)
+		history = model.train(DATA_DIR, labels, test_ratio=0.3, epochs=3)
 		assert history is not None
 
 		# Do a simple prediction

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0',
+    version='2.0',
 
     description='Automatic text classification tool',
     # long_description=long_description,
@@ -73,7 +73,7 @@ setup(
         'scipy~=0.18',
         'gensim~=0.13',
         'scikit-learn~=0.18',
-        'keras~=1.2.2',
+        'keras~=2.0',
         'h5py~=2.6',
     ],
 


### PR DESCRIPTION
As mentioned before (in #97), Keras 2.0 that Magpie depends on introduced some breaking changes, so in order to keep up to date with it, we need to release a new version of Magpie.

There are no changes to functionality, only updates to the API so it works with new Keras. I also took advantage to change the main object name from `MagpieModel` to `Magpie` which I wanted to do for a long time. These are breaking changes, therefore we release them under v2.0. Version 1.0 is tagged and can still be installed from GHE.

Changes:
 - `MagpieModel` -> `Magpie` as a name of the main object
 - `nb_epochs` -> `epochs` as in the new Keras
 - rename a few keyword arguments in the Keras layers
 - rewrite the NN model definitions to conform to the new Keras functional API
 - update the `batch_train()` function, which now takes in the number of batches and not the number of samples
 - add a paragraph in the docs explaining the difference between v1.0 and v2.0
 - added a test for `batch_train()` that uses an RNN
 - bump the version in `setup.py` to 2.0 🍾 

@kaplun 