### PR TITLE
Fix 'UnicodeDecodeError' error if locale encoding is not UTF-8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Training...
 
 
 ## Short introduction
-To train the model you need to have a large corpus of labeled data in a text format. An example corpus can be found under `data/hep-categories` directory. Magpie looks for `.txt` files containing the text to predict on and corresponding `.lab` files with assigned labels in separate lines. A pair of files containing the labels and the text should have the same name and differ only in extensions e.g.
+To train the model you need to have a large corpus of labeled data in a text format encoded as UTF-8. An example corpus can be found under data/hep-categories directory. Magpie looks for `.txt` files containing the text to predict on and corresponding `.lab` files with assigned labels in separate lines. A pair of files containing the labels and the text should have the same name and differ only in extensions e.g.
 
 ```
 $ ls data/hep-categories
@@ -61,6 +61,7 @@ Trained models can be used for prediction with methods:
  ('Experiment-HEP', 0.64958507),
  ('Theory-HEP', 0.20917746)]
 ```
+
 ## Saving & loading the model
 A `Magpie` object consists of three components - the word2vec mappings, a scaler and a `keras` model. In order to train Magpie you can either provide the word2vec mappings and a scaler in advance or let the program compute them for you on the training data. Usually you would want to train them yourself on a full dataset and reuse them afterwards. You can use the provided functions for that purpose:
 

--- a/magpie/base/document.py
+++ b/magpie/base/document.py
@@ -25,7 +25,7 @@ class Document(object):
             self.filepath = filepath
             self.filename = os.path.basename(filepath)
 
-            with io.open(filepath, 'r') as f:
+            with io.open(filepath, 'r', encoding='utf-8') as f:
                 self.text = f.read()
 
         self.wordset = self.compute_wordset()


### PR DESCRIPTION
Fix the error like "UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 796: ordinal not in range(128)". Read file with UTF-8 encode, not the locale encoding from 'locale.getpreferredencoding(False)'.

In io.open(), if encoding is not specified the encoding used is platform dependent: locale.getpreferredencoding(False) is called to get the current locale encoding.